### PR TITLE
[DBView] - Identificar clientes consumindo dados da Transactionlog

### DIFF
--- a/cmd/replicate.go
+++ b/cmd/replicate.go
@@ -90,6 +90,7 @@ func runReplicate() {
 		Database: viper.GetString("local-database.target_database"),
 		SslMode:  viper.GetString("local-database.ssl"),
 		Password: viper.GetString("local-database.password"),
+		AppName: "local",
 	}
 
 	log.Debugf("Using local connection with '%s'", localConn.ToString())
@@ -101,6 +102,7 @@ func runReplicate() {
 		Database: viper.GetString("remote-database.database"),
 		SslMode:  viper.GetString("remote-database.ssl"),
 		Password: viper.GetString("remote-database.password"),
+		AppName:  "dbview_client_" + viper.GetString("customer"),
 	}
 
 	log.Debugf("Using remote connection with '%s'", remoteConn.ToString())

--- a/setup/helpers.go
+++ b/setup/helpers.go
@@ -23,6 +23,7 @@ type ConnectionDetails struct {
 	Database string
 	SslMode  string
 	Port     int
+	AppName  string
 }
 
 var c *ConnectionDetails
@@ -55,6 +56,10 @@ func (c ConnectionDetails) ToString() string {
 
 	if c.Port > 0 {
 		returnData += fmt.Sprintf("port=%d ", c.Port)
+	}
+
+	if c.AppName != "" {
+		returnData += fmt.Sprintf("application_name=%s ", c.AppName)
 	}
 
 	return strings.Trim(returnData, " ")

--- a/setup/setup_test.go
+++ b/setup/setup_test.go
@@ -17,9 +17,10 @@ var _ = Describe("Setup database user and groups", func() {
 			Database: "dbview_tests",
 			SslMode:  "disable",
 			Password: "superTest!",
-			Port:     5432}
+			Port:     5432,
+			AppName: "teste"}
 
-		sampleConnString = "user=dbview_tests password=superTest! dbname=dbview_tests sslmode=disable port=5432"
+		sampleConnString = "user=dbview_tests password=superTest! dbname=dbview_tests sslmode=disable port=5432 application_name=teste"
 
 		testUserName  = "dbview"
 		wrongUserName = "missing_user_for_this_database"


### PR DESCRIPTION
- Adicionamos o parâmetro `application_name`  nas strings de conexão para logar o usuário que está consumindo a transactionlog.
- Na conexão local foi passado o valor `local`
- Na conexão remota foi passado o valor `dbview_client_ + customer` 

Issue com detalhes da implementação: GITLAB#339